### PR TITLE
Allow python-dateutil to be 2.8.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.19.1
-python-dateutil~=2.7.5
+python-dateutil>=2.7.5


### PR DESCRIPTION
Allow compatibility with packages requiring `python-dateutil>=2.8.*`.

From `python-dateutil` changelog the parser wasn't modified and should therefore work without issues with `sat-stac`