### PR TITLE
fix: Use new importlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python
+import importlib.util
+import importlib.machinery
 from setuptools import setup, find_packages
-from imp import load_source
 from os import path
 import io
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 __version__ = load_source('satstac.version', 'satstac/version.py').__version__
 


### PR DESCRIPTION
As recommended by <https://docs.python.org/3/whatsnew/3.12.html#imp>.

This is sufficient to make the package build using Nix, but I've not tested the result yet.

Closes #74.